### PR TITLE
Construct image identifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.34.13
 requests==2.31.0
 python-dotenv==1.0.0
 aiohttp==3.9.1
+loguru==0.7.2


### PR DESCRIPTION
The current identifier of ECR Images is set to the image digest. This has been updated to <repositoryName>:<Tag> which is consistent with how most containers references docker images. If an Image has more than 1 tag, we recreate the image with each of it's tags, allowing internal developers to select which image they want to use for deployment.